### PR TITLE
fix(boilerplate): fix memory leak

### DIFF
--- a/boilerplate.c
+++ b/boilerplate.c
@@ -110,6 +110,7 @@ void boilerplate_app_free(Boilerplate* app) {
     view_dispatcher_remove_view(app->view_dispatcher, BoilerplateViewIdScene3);
     view_dispatcher_remove_view(app->view_dispatcher, BoilerplateViewIdSettings);
     view_dispatcher_remove_view(app->view_dispatcher, BoilerplateViewIdStartscreen);
+    button_menu_free(app->button_menu);
     submenu_free(app->submenu);
     variable_item_list_free(app->variable_item_list);
     boilerplate_scene_1_free(app->boilerplate_scene_1);


### PR DESCRIPTION
Ran the following command: `rg -o '\b\w+_(alloc|free)\w*\s*\(' boilerplate.c | sort | uniq`
and found that button_menu_alloc did not have a free called paired with it:

```bash
boilerplate_app_alloc(
boilerplate_app_free(
boilerplate_scene_1_alloc(
boilerplate_scene_1_free(
boilerplate_scene_2_alloc(
boilerplate_scene_2_free(
boilerplate_startscreen_alloc(
boilerplate_startscreen_free(
button_menu_alloc(
# MISSING button_menu_free(
furi_string_alloc(
furi_string_free(
number_input_alloc(
number_input_free(
scene_manager_alloc(
scene_manager_free(
submenu_alloc(
submenu_free(
text_input_alloc(
text_input_free(
variable_item_list_alloc(
variable_item_list_free(
view_dispatcher_alloc(
view_dispatcher_free(
```

I added the free call in `boilerplate_app_free` and ran `ufbt build` to check compilation:
```bash
scons: Entering directory `/Users/arod183/.ufbt/current/scripts/ufbt'
	ICONS	/Users/arod183/.ufbt/build/boilerplate/boilerplate_icons.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene.c
	CC	/Users/arod183/.ufbt/build/boilerplate/boilerplate_icons.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_scene_4.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/views/boilerplate_startscreen.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/helpers/boilerplate_speaker.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_scene_3.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/helpers/boilerplate_led.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/views/boilerplate_scene_2.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_scene_2.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/views/boilerplate_scene_1.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/helpers/boilerplate_haptic.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_scene_6.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_scene_1.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_startscreen.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_menu.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_settings.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/boilerplate.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/scenes/boilerplate_scene_scene_5.c
	CC	/Users/arod183/ProgrammingProjects/flipper/flipper-zero-fap-boilerplate/helpers/boilerplate_storage.c
	LINK	/Users/arod183/.ufbt/build/boilerplate_d.elf
	APPMETA	/Users/arod183/.ufbt/build/boilerplate.fap
	FAP	/Users/arod183/.ufbt/build/boilerplate.fap
	FASTFAP	/Users/arod183/.ufbt/build/boilerplate.fap
	APPCHK	/Users/arod183/.ufbt/build/boilerplate.fap
		Target: 7, API: 87.1
```

